### PR TITLE
chore(): test fix to appversion example resources

### DIFF
--- a/examples/appengine/v1beta1/domainmapping.yaml
+++ b/examples/appengine/v1beta1/domainmapping.yaml
@@ -8,5 +8,6 @@ metadata:
   name: domain-mapping
 spec:
   forProvider:
+    domainName: "domain-name"
     sslSettings:
-    - sslManagementType: AUTOMATIC
+      sslManagementType: AUTOMATIC

--- a/examples/appengine/v1beta1/flexibleappversion.yaml
+++ b/examples/appengine/v1beta1/flexibleappversion.yaml
@@ -14,9 +14,9 @@ spec:
         targetUtilization: 0.5
     deployment:
       zip:
-        sourceUrl: https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}
+        sourceUrl: https://storage.googleapis.com/${data.bucket_name}/${data.object_name}
     entrypoint:
-      shell: node ./app.js
+      shell: node app.js
     envVariables:
       port: "8080"
     flexibleRuntimeSettings:
@@ -33,16 +33,12 @@ spec:
     livenessCheck:
       path: /
     noopOnDestroy: true
-    projectSelector:
-      matchLabels:
-        testing.upbound.io/example-name: gae_api
+    project: appeng-flex
     readinessCheck:
       path: /
     runtime: nodejs
     service: default
-    serviceAccountSelector:
-      matchLabels:
-        testing.upbound.io/example-name: custom_service_account
+    serviceAccount: ${data.service_account_name}@appeng-flex.iam.gserviceaccount.com
 
 ---
 
@@ -57,9 +53,7 @@ metadata:
 spec:
   forProvider:
     locationId: us-central
-    projectSelector:
-      matchLabels:
-        testing.upbound.io/example-name: my_project
+    project: appeng-flex
 
 ---
 
@@ -104,8 +98,8 @@ metadata:
   annotations:
     meta.upbound.io/example-id: appengine/v1beta1/flexibleappversion
   labels:
-    testing.upbound.io/example-name: custom_service_account
-  name: custom-service-account
+    testing.upbound.io/example-name: ${data.service_account_name}
+  name: ${data.service_account_name}
 spec:
   forProvider:
     displayName: Custom Service Account
@@ -119,8 +113,8 @@ metadata:
   annotations:
     meta.upbound.io/example-id: appengine/v1beta1/flexibleappversion
   labels:
-    testing.upbound.io/example-name: bucket
-  name: bucket
+    testing.upbound.io/example-name: test-bucket
+  name: ${data.bucket_name}
 spec:
   forProvider:
     location: US
@@ -134,12 +128,12 @@ metadata:
   annotations:
     meta.upbound.io/example-id: appengine/v1beta1/flexibleappversion
   labels:
-    testing.upbound.io/example-name: object
-  name: object
+    testing.upbound.io/example-name: node-js-project
+  name: node-js-project
 spec:
   forProvider:
     bucketSelector:
       matchLabels:
-        testing.upbound.io/example-name: bucket
-    name: hello-world.zip
-    source: ./test-fixtures/hello-world.zip
+        testing.upbound.io/example-name: ${data.bucket_name}
+    name: ${data.object_name}
+    source: ${data.object_source_path}

--- a/examples/appengine/v1beta1/flexibleappversion.yaml
+++ b/examples/appengine/v1beta1/flexibleappversion.yaml
@@ -127,6 +127,7 @@ kind: BucketObject
 metadata:
   annotations:
     meta.upbound.io/example-id: appengine/v1beta1/flexibleappversion
+    upjet.upbound.io/manual-intervention: A nodejs server files compiled as a zip object needs to be set up and uploaded to the bucket from above. The FlexibleAppVersion resources will reference this same zip file."
   labels:
     testing.upbound.io/example-name: node-js-project
   name: node-js-project

--- a/examples/appengine/v1beta1/flexibleappversion.yaml
+++ b/examples/appengine/v1beta1/flexibleappversion.yaml
@@ -113,7 +113,7 @@ metadata:
   annotations:
     meta.upbound.io/example-id: appengine/v1beta1/flexibleappversion
   labels:
-    testing.upbound.io/example-name: test-bucket
+    testing.upbound.io/example-name: ${data.bucket_name}
   name: ${data.bucket_name}
 spec:
   forProvider:

--- a/examples/appengine/v1beta1/flexibleappversion.yaml
+++ b/examples/appengine/v1beta1/flexibleappversion.yaml
@@ -9,35 +9,35 @@ metadata:
 spec:
   forProvider:
     automaticScaling:
-    - coolDownPeriod: 120s
+      coolDownPeriod: 120s
       cpuUtilization:
-      - targetUtilization: 0.5
+        targetUtilization: 0.5
     deployment:
-    - zip:
-      - sourceUrl: https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}
+      zip:
+        sourceUrl: https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}
     entrypoint:
-    - shell: node ./app.js
+      shell: node ./app.js
     envVariables:
       port: "8080"
     flexibleRuntimeSettings:
-    - operatingSystem: ubuntu22
+      operatingSystem: ubuntu22
       runtimeVersion: "20"
     handlers:
     - authFailAction: AUTH_FAIL_ACTION_REDIRECT
       login: LOGIN_REQUIRED
       securityLevel: SECURE_ALWAYS
       staticFiles:
-      - path: my-other-path
+        path: my-other-path
         uploadPathRegex: .*\/my-path\/*
       urlRegex: .*\/my-path\/*
     livenessCheck:
-    - path: /
+      path: /
     noopOnDestroy: true
     projectSelector:
       matchLabels:
         testing.upbound.io/example-name: gae_api
     readinessCheck:
-    - path: /
+      path: /
     runtime: nodejs
     service: default
     serviceAccountSelector:

--- a/examples/appengine/v1beta1/servicesplittraffic.yaml
+++ b/examples/appengine/v1beta1/servicesplittraffic.yaml
@@ -30,7 +30,7 @@ spec:
     deleteServiceOnDestroy: true
     deployment:
       zip:
-        sourceUrl: https://storage.googleapis.com/bucket-crosspla-sandbox-infrasec-1601/test.zip
+        sourceUrl: https://storage.googleapis.com/${data.bucket_name}/${data.object_name}
     entrypoint:
       shell: npm run start
     envVariables:
@@ -52,9 +52,9 @@ spec:
   forProvider:
     deployment:
       zip:
-        sourceUrl: https://storage.googleapis.com/bucket-crosspla-sandbox-infrasec-1601/test.zip
+        sourceUrl: https://storage.googleapis.com/${data.bucket_name}/${data.object_name}
     entrypoint:
-      shell: node app.js
+      shell: node ./app.js
     envVariables:
       port: "8080"
     noopOnDestroy: true
@@ -70,8 +70,8 @@ metadata:
     meta.upbound.io/example-id: appengine/v1beta1/servicesplittraffic
     upjet.upbound.io/manual-intervention: A nodejs server files compiled as a zip object needs to be set up and uploaded to the bucket from above. The StandardAppVersion resources will reference this same zip file."
   labels:
-    testing.upbound.io/example-name: bucket
-  name: bucket
+    testing.upbound.io/example-name: ${data.bucket_name}
+  name: ${data.bucket_name}
 spec:
   forProvider:
     location: US
@@ -90,6 +90,6 @@ spec:
   forProvider:
     bucketSelector:
       matchLabels:
-        testing.upbound.io/example-name: bucket
-    name: hello-world.zip
-    source: ./test-fixtures/hello-world.zip
+        testing.upbound.io/example-name: ${data.bucket_name}
+    name: ${data.object_name}
+    source: ${data.object_name}

--- a/examples/appengine/v1beta1/servicesplittraffic.yaml
+++ b/examples/appengine/v1beta1/servicesplittraffic.yaml
@@ -10,9 +10,9 @@ spec:
   forProvider:
     migrateTraffic: false
     split:
-    - allocations:
-        ${(google_app_engine_standard_app_version.liveapp_v1.version_id)}: 0.75
-        ${(google_app_engine_standard_app_version.liveapp_v2.version_id)}: 0.25
+      allocations:
+        liveapp-v3: "0.50"
+        liveapp-v4: "0.50"
       shardBy: IP
 
 ---
@@ -23,16 +23,16 @@ metadata:
   annotations:
     meta.upbound.io/example-id: appengine/v1beta1/servicesplittraffic
   labels:
-    testing.upbound.io/example-name: liveapp_v1
-  name: liveapp-v1
+    testing.upbound.io/example-name: liveapp_v3
+  name: liveapp-v3
 spec:
   forProvider:
     deleteServiceOnDestroy: true
     deployment:
-    - zip:
-      - sourceUrl: https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}
+      zip:
+        sourceUrl: https://storage.googleapis.com/bucket-crosspla-sandbox-infrasec-1601/test.zip
     entrypoint:
-    - shell: node ./app.js
+      shell: npm run start
     envVariables:
       port: "8080"
     runtime: nodejs20
@@ -46,15 +46,15 @@ metadata:
   annotations:
     meta.upbound.io/example-id: appengine/v1beta1/servicesplittraffic
   labels:
-    testing.upbound.io/example-name: liveapp_v2
-  name: liveapp-v2
+    testing.upbound.io/example-name: liveapp_v4
+  name: liveapp-v4
 spec:
   forProvider:
     deployment:
-    - zip:
-      - sourceUrl: https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}
+      zip:
+        sourceUrl: https://storage.googleapis.com/bucket-crosspla-sandbox-infrasec-1601/test.zip
     entrypoint:
-    - shell: node ./app.js
+      shell: node app.js
     envVariables:
       port: "8080"
     noopOnDestroy: true
@@ -68,6 +68,7 @@ kind: Bucket
 metadata:
   annotations:
     meta.upbound.io/example-id: appengine/v1beta1/servicesplittraffic
+    upjet.upbound.io/manual-intervention: A nodejs server files compiled as a zip object needs to be set up and uploaded to the bucket from above. The StandardAppVersion resources will reference this same zip file."
   labels:
     testing.upbound.io/example-name: bucket
   name: bucket


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I run Uptest locally with `make e2e` by setting those env variables:

```
export UPTEST_EXAMPLE_LIST="examples/appengine/v1beta1/<resource>.yaml"
export UPTEST_GCP_PROJECT="my-gcp-project"
export UPTEST_CLOUD_CREDENTIALS="gcp-sa-creds" 
```
The result of this tests was :

- FlexibleApp Version
<img width="1002" alt="FlexibleAppVersion-SuccessE2E" src="https://github.com/user-attachments/assets/7953e6f8-ac92-48d0-823b-e7ed345988ef" />

- DomainMapping
<img width="979" alt="DomainMapping - SuccessE2E" src="https://github.com/user-attachments/assets/67cd91b9-e198-4853-8695-06133fc82f29" />

- ServicesSplitTraffic (in progress)

I also tested it manually :

```
k apply -f examples/storage/v1beta1/<resource>.yaml -n upbound-system
kubectl get managed
```
The result of this tests were:

- FlexibleApp Version
<img width="829" alt="FlexibleAppVersion - ManagedList" src="https://github.com/user-attachments/assets/509e73a4-d431-4f7c-b818-d307b017e14a" />

- DomainMapping (incoming)

- ServicesSplitTraffic (in progress)

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
